### PR TITLE
Allow all origins for CORS

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins 'https://secret-meadow-99085.herokuapp.com/'
+    origins '*'
 
     resource '*',
       headers: :any,


### PR DESCRIPTION
# Allow all origins for CORS

This PR addresses an issue regarding CORS policy not permitting resource sharing outside of `https://secret-meadow-99085.herokuapp.com/`. To correct this, the CORS configuration file has been updated to permit all (`*`) origins.

## Type of change
Please uncheck options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Add Testing
- [ ] Refactor

## Checklist:
- [X] My code follows the Turing style guidelines
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas