### PR TITLE
FAQ endpoint

### DIFF
--- a/app/controllers/api/v1/questions_controller.rb
+++ b/app/controllers/api/v1/questions_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::QuestionsController < ApplicationController
+  def index
+    questions = Question.all
+    render json: questions.to_json(only: [:faq, :answer])
+  end
+end

--- a/app/controllers/api/v1/tips_controller.rb
+++ b/app/controllers/api/v1/tips_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::TipsController < ApplicationController
   def show
     tip = Tip.random_tip
-    render json: tip
+    render json: tip.to_json(only: :description)
   end
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,0 +1,4 @@
+class Question < ApplicationRecord
+  validates :faq, presence: true
+  validates :answer, presence: true
+end

--- a/app/models/tip.rb
+++ b/app/models/tip.rb
@@ -4,5 +4,4 @@ class Tip < ApplicationRecord
   def self.random_tip
     Tip.all.sample
   end
-  
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins 'https://secret-meadow-99085.herokuapp.com/'
+    origins '*'
 
     resource '*',
       headers: :any,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get '/tips', to: 'tips#show'
+      get '/faq', to: 'questions#index'
     end
   end
 end

--- a/db/migrate/20200728181812_create_questions.rb
+++ b/db/migrate/20200728181812_create_questions.rb
@@ -1,0 +1,10 @@
+class CreateQuestions < ActiveRecord::Migration[5.1]
+  def change
+    create_table :questions do |t|
+      t.string :faq
+      t.string :answer
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200728154058) do
+ActiveRecord::Schema.define(version: 20200728181812) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "questions", force: :cascade do |t|
+    t.string "faq"
+    t.string "answer"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "tips", force: :cascade do |t|
     t.string "description"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,3 +15,8 @@ Tip.create(description: "Buy local. The closer to home products are made and bou
 Tip.create(description: "Try to cut out plastic, especially types which cannot be recycled locally.")
 Tip.create(description: "Electronics that are plugged in still consume energy.  Unplug unused electronics to save money on your energy bill!")
 Tip.create(description: "Eat less meat!  Meat is one of the biggest contributors to climate change.")
+
+Question.destroy_all
+
+Question.create(faq: 'Overview', answer: 'Solarizer is a web app for solar energy enthusiasts seeking estimates on electricity production of a photovoltaic (PV) system based on a few simple inputs.')
+Question.create(faq: 'Get Started', answer: 'Users provide information about the system \'s location, basic design parameters, and an optional historical monthly energy usage. Solarizer calculates estimates of the system\'s annual and monthly electricity production, and an estimate of the value of that electricity.')

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,5 +18,12 @@ Tip.create(description: "Eat less meat!  Meat is one of the biggest contributors
 
 Question.destroy_all
 
-Question.create(faq: 'Overview', answer: 'Solarizer is a web app for solar energy enthusiasts seeking estimates on electricity production of a photovoltaic (PV) system based on a few simple inputs.')
-Question.create(faq: 'Get Started', answer: 'Users provide information about the system \'s location, basic design parameters, and an optional historical monthly energy usage. Solarizer calculates estimates of the system\'s annual and monthly electricity production, and an estimate of the value of that electricity.')
+Question.create(faq: "Overview", answer: "Solarizer is a web app for solar energy enthusiasts seeking estimates on electricity production of a photovoltaic (PV) system based on a few simple inputs.")
+Question.create(faq: "Get Started", answer: "Users provide information about the system \'s location, basic design parameters, and an optional historical monthly energy usage. Solarizer calculates estimates of the system \'s annual and monthly electricity production, and an estimate of the value of that electricity.")
+Question.create(faq: "System Size", answer: "System Size is the DC (direct current) power rating of the PV array in kilowatts (kW) at standard test conditions. The default size if usually 4kW.")
+Question.create(faq: "Module Type", answer: "Module Type describes the PV modules in the solar array.  Most module types will be Standard.")
+Question.create(faq: "Array Type", answer: "The array type describes whether the PV modules in the array are fixed, or whether they move to track the movement of the sun across the sky with one or two axes of rotation. The default value is for a fixed array, For systems with fixed arrays, you can choose between an open rack or a roof mount option. The open rack option is appropriate for ground-mounted systems")
+Question.create(faq: "System Losses", answer: "The system losses account for performance losses you would expect in a real system that are not explicitly calculated by Solarizer. Several categories make up the system losses, including soiling, shading, snow, and more.  The default system loss percentage is 14%")
+Question.create(faq: "Tilt", answer: "The tilt angle is the angle from horizontal of the PV modules in the array. For a fixed array, the tilt angle is genereally between 0-45%. The default value is 20 degrees.")
+Question.create(faq: "Azimuth", answer: "For a fixed array, the azimuth angle is the angle clockwise from true north describing the direction that the array faces. An azimuth angle of 180° is for a south-facing array, and an azimuth angle of zero degrees is for a north-facing array. For reference: N = 0\u00B0, NE = 45\u00B0, E = 90\u00B0, SE = 135\u00B0, S = 180\u00B0, SW = 225\u00B0, W = 270\u00B0, SW = 315 \u00B0")
+Question.create(faq: "Retail Electricty Rate", answer: "The national average rate is 11 cents per kWh")

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe Question, type: :model do
+  describe "validations" do
+    it { should validate_presence_of :faq }
+    it { should validate_presence_of :answer }
+  end
+end

--- a/spec/requests/faq_spec.rb
+++ b/spec/requests/faq_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe 'FAQ endpoint' do
+  it 'returns an index of FAQ questions and answers' do
+    faq1 = Question.create(faq: 'Overview', answer: 'Solarizer is a web app for solar energy enthusiasts seeking estimates on electricity production of a photovoltaic (PV) system based on a few simple inputs.')
+    faq2 = Question.create(faq: 'Get Started', answer: 'Users provide information about the system \'s location, basic design parameters, and an optional historical monthly energy usage. Solarizer calculates estimates of the system\'s annual and monthly electricity production, and an estimate of the value of that electricity.')
+
+    get api_v1_faq_path
+
+    expect(response).to be_successful
+
+    parsed = JSON.parse(response.body, symbolize_names: true)
+
+    expect(parsed.length).to eq(2)
+    expect(parsed).to include({"faq": faq1.faq, "answer": faq1.answer})
+    expect(parsed).to include({"faq": faq2.faq, "answer": faq2.answer})
+  end
+end

--- a/spec/requests/tips_spec.rb
+++ b/spec/requests/tips_spec.rb
@@ -1,17 +1,18 @@
 require 'rails_helper'
 
-describe 'Tips API' do
-  it 'sends a tip' do
+describe 'Tips Endpoint' do
+  it 'returns a random tip' do
     tip1 = Tip.create!(description: "Turn it off. Energy conservation is one of the most important things you can do to reduce your carbon footprint.")
     tip2 = Tip.create!(description: "Electronics that are plugged in still consume energy.  Unplug unused electronics to save money on your energy bill!")
     tips = [tip1.description, tip2.description]
 
-    get '/api/v1/tips'
+    get api_v1_tips_path
 
     expect(response).to be_successful
 
     parsed = JSON.parse(response.body, symbolize_names: true)
-    
+
+    expect(parsed.length).to eq(1)
     expect(tips).to include(parsed[:description])
   end
 end


### PR DESCRIPTION
# Add endpoint to return all FAQ questions/answers

This PR adds an endpoint at /api/v1/faq which returns an array of faq/answer object in the following format:
```json
[
    {
        "faq": "Overview",
        "answer": "Solarizer is a web app for solar energy enthusiasts seeking estimates on electricity production of a photovoltaic (PV) system based on a few simple inputs."
    },
    {
        "faq": "Get Started",
        "answer": "Users provide information about the system 's location, basic design parameters, and an optional historical monthly energy usage. Solarizer calculates estimates of the system's annual and monthly electricity production, and an estimate of the value of that electricity."
    }
]
```

In addition, this PR strips the id from being returns on the /api/v1/tips endpoint and slightly modifies the existing tips request spec to assert that only one tip should ever be returned.

## Type of change
Please uncheck options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Add Testing
- [X] Refactor

## Checklist:
- [X] My code follows the Turing style guidelines
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas